### PR TITLE
blenderRCBPanel: add the check on joint limits

### DIFF
--- a/script/blenderRCBPanel.py
+++ b/script/blenderRCBPanel.py
@@ -81,6 +81,7 @@ def move(dummy):
         ienc    = rcb_instance.ienc
         encs    = rcb_instance.encs
         iax     = rcb_instance.iax
+        joint_limits     = rcb_instance.joint_limits
         # Get the targets from the rig
         ok_enc = ienc.getEncoders(encs.data())
         if not ok_enc:
@@ -254,11 +255,11 @@ class WM_OT_Connect(bpy.types.Operator):
         joint_limits = []
 
         for joint in range(0, ipos.getAxes()):
-            min = []
-            max = []
+            min = yarp.Vector(1)
+            max = yarp.Vector(1)
             icm.setControlMode(joint, yarp.VOCAB_CM_POSITION_DIRECT)
-            ilim.getLimits(joint, min, max)
-            joint_limits[joint] = (min, max)
+            ilim.getLimits(joint, min.data(), max.data())
+            joint_limits.append([min.get(0), max.get(0)])
 
 
 


### PR DESCRIPTION
This PR adds an extra check in the RCB panel, for skipping the targets that are outside the joints' boundaries.

The limits are already set in the rig, but also if the joint in the rig does not goes over the limit, in the blender UI the angle value is not capped and it seems that from the API you get that value that is outside the boundaries, leading to a situation where the target can never be reached by the real robot.

TO BE TESTED(at least on the simulator)