### PR TITLE
urdfToBlender: add support for meshes as geometric shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added the support in urdfToBlender for the basic geometries
 
 ## [0.1.0] - 2021-08-30
 - Added `blenderRCBPanel` python script that spawns a panel for controlling parts of


### PR DESCRIPTION
This PR adds the support in `urdfToBlender` for import meshes as basic geometries, e.g the icub eyes: 


![immagine](https://user-images.githubusercontent.com/19152494/133089079-eda1a19a-0aba-42ab-989a-1a2de4b740d2.png)
