### PR TITLE
Add iCubBlenderV2_5_visuomanip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 - Added the support in urdfToBlender for the basic geometries
+- Added `iCubBlenderV2_5_visuomanip.blend`.
 
 ## [0.1.0] - 2021-08-30
+
 - Added `blenderRCBPanel` python script that spawns a panel for controlling parts of
   the robot(for now tested only with iCub).
 - Added `urdfToBlender` python script that creates a rig starting from a urdf of a robot.


### PR DESCRIPTION
This PR adds the rig `iCubBlenderV2_5_visuomanip.blend`, that starting from the urdf of `iCubGazeboV2_5_visuomanip`, the mechanics of the eyes and of the fingers has been added see:

https://user-images.githubusercontent.com/19152494/134181507-55d1e352-280c-4f88-8691-3ec165b44fdc.mp4

https://user-images.githubusercontent.com/19152494/134175161-12a71e47-6386-4c13-bad1-3f05db014515.mp4

cc @traversaro @xEnVrE
