### PR TITLE
urdfToBlender: add the possibility to run it from command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `urdfToBlender`
 
 - Added the support in urdfToBlender for the basic geometries
+- Added the possibility to run it headless.
 
 ### `rigs`
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ conda env config vars set PYTHONPATH=/where/the/bindings/are/installed
 where `<blender_py_ver>` is the python version used inside Blender.
 
 ### Usage
+
+#### With GUI
+
 Once installed correctly the dependencies run:
 
 (Windows Powershell)
@@ -47,6 +50,21 @@ It will open a dialog for selecting the urdf to be converted to rig.
 ![immagine](https://user-images.githubusercontent.com/19152494/126337119-6b899183-1f2a-413c-8b88-4e5727818891.png)
 
 After selecting the urdf, the script creates the rig of the robot in term of armature and meshes.
+
+#### Without GUI
+
+It is also possible to run this script from the command line interface, in this case you have to specify the `urdf_fiename`
+to be converted and optionally the `blend_filename` to be saved(by default it saves `robot.blend` in the current directory).
+
+(Windows Powershell)
+```
+ "C:\Program Files\Blender Foundation\Blender <blender_version>\blender.exe" --python-use-system-env -b -P "C:\where\you\have\blender-robotics-utils\script\urdfToBlender.py" -- --urdf_filename "C:\where\you\have\model.urdf" --blend_filename "C:\where\you\want\to\save\myrobot.blend"
+
+```
+(Linux & macOs)
+```
+$ blender --python-use-system-env -b -P "/where/you/have/blender-robotics-utils/script/urdfToBlender.py" -- --urdf_filename "/where/you/have/model.urdf" --blend_filename "/where/you/want/to/save/myrobot.blend"
+```
 
 ### Examples
 

--- a/script/urdfToBlender.py
+++ b/script/urdfToBlender.py
@@ -9,6 +9,7 @@ import copy
 import mathutils
 import math
 import os
+import sys
 import idyntree.bindings as iDynTree
 import xml.etree.ElementTree as ET
 
@@ -356,12 +357,26 @@ def unregister():
     bpy.utils.unregister_class(OT_TestOpenFilebrowser)
 
 # Main function
-def main():
+def main(urdf_filename, blend_filename):
     register()
-    bpy.ops.test.open_filebrowser('INVOKE_DEFAULT')
+    if urdf_filename is None:
+        bpy.ops.test.open_filebrowser('INVOKE_DEFAULT')
+    else:
+        rigify(urdf_filename)
+        bpy.ops.wm.save_as_mainfile(filepath=blend_filename)
 
 
 
 # Execute main()
 if __name__=='__main__':
-    main()
+    argv = sys.argv
+    try:
+        urdf_filename = argv[argv.index("--urdf_filename") + 1]
+    except ValueError:
+        urdf_filename = None
+    try:
+        blend_filename = argv[argv.index("--blend_filename") + 1]
+    except ValueError:
+        blend_filename = "./robot.blend"
+    main(urdf_filename, blend_filename)
+


### PR DESCRIPTION
It is now possible to create a rig from an urdf in a headless system as follow:

(Windows Powershell)
```
 "C:\Program Files\Blender Foundation\Blender <blender_version>\blender.exe" --python-use-system-env -b -P "C:\where\you\have\blender-robotics-utils\script\urdfToBlender.py" -- --urdf_filename "C:\where\you\have\model.urdf" --blend_filename "C:\where\you\want\to\save\myrobot.blend"

```
(Linux & macOs)
```
$ blender --python-use-system-env -b -P "/where/you/have/blender-robotics-utils/script/urdfToBlender.py" -- --urdf_filename "/where/you/have/model.urdf" --blend_filename "/where/you/want/to/save/myrobot.blend"
```