### PR TITLE
[urdfToBlender] Made Panel installable as addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `urdfToBlender`
+
+- Code refactored for displaying the converter as panel that can be installed as addon.
+
 ### `blenderRCBPanel`
 
 - Added robot's parts configuration through a JSON file structured as the [proposed template](https://github.com/robotology/blender-robotics-utils/blob/master/script/conf/parts.json)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository is maintained by:
 
 
 ## urdfToBlender
-Python script that given the urdf of a robot as input, define the complete rig, in terms of bones, meshes and joint limits.
+Panel/Python script that given the urdf of a robot as input, define the complete rig, in terms of bones, meshes and joint limits.
 ### Dependencies
 - Blender > 2.79
 - [iDynTree](https://github.com/robotology/idyntree) python bindings
@@ -44,8 +44,21 @@ Once installed correctly the dependencies run:
 $ blender --python-use-system-env
 ```
 
-Go to "Scripting" section, open `urdfToBlender`, then run.
-It will open a dialog for selecting the urdf to be converted to rig.
+Then install the addon
+
+```console
+$ cd ~/.config/blender/<blender_version>/scripts/addons/
+$ ln -s /where/you/cloned/blender-robotics-utils/script/urdfToBlender  urdfToBlender
+```
+Going to Edit > Preferences > Add-ons > Testing:
+
+![immagine](https://user-images.githubusercontent.com/19152494/154102247-16bfaf2e-1387-467f-a878-ed7cec306111.png)
+
+If everything went fine you should have this panel on the right under the `Tools` section:
+
+![immagine](https://user-images.githubusercontent.com/19152494/154102335-76c5312a-81ea-46b5-92cc-93d0668596e7.png)
+
+After clicking "Select the urdf" it will be opened a file browse such as:
 
 ![immagine](https://user-images.githubusercontent.com/19152494/126337119-6b899183-1f2a-413c-8b88-4e5727818891.png)
 
@@ -95,7 +108,7 @@ Select it to be able to use it
 ![issue914-1](https://user-images.githubusercontent.com/19833605/153264876-878da020-3fdb-4c08-b866-ae3a507d5658.jpg)
 
 
-If every went fine you should have this panel on the right under the `Tools` section.
+If everything went fine you should have this panel on the right under the `Tools` section.
 First of all you have to configure it loading a `.json` file representing the structure of your robot like this one:
 ```json
 {

--- a/script/blenderRCBPanel/__init__.py
+++ b/script/blenderRCBPanel/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2006-2022 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
 bl_info = {
     "name": "RemoteControlBoard Panel",
     "description": "Panel for attaching the remote_controlboard of a YARP-based robot",

--- a/script/urdfToBlender/__init__.py
+++ b/script/urdfToBlender/__init__.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2006-2022 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
+bl_info = {
+    "name": "URDF to Blender Panel",
+    "description": "Panel converting urdf to .blend",
+    "author": "Nicogene",
+    "version": (0, 0, 1),
+    "blender": (2, 80, 0),
+    "location": "3D View > Tools",
+    "warning": "",  # used for warning icon and text in addons panel
+    "wiki_url": "",
+    "tracker_url": "",
+    "category": "Development"
+}
+
+import bpy
+
+from bpy.props import (StringProperty,
+                       BoolProperty,
+                       IntProperty,
+                       FloatProperty,
+                       FloatVectorProperty,
+                       EnumProperty,
+                       PointerProperty,
+                       CollectionProperty
+                       )
+
+from .urdfToBlender import (OBJECT_PT_urdf2blender_converter,
+                            WM_OT_OpenFilebrowser)
+
+# ------------------------------------------------------------------------
+#    Registration
+# ------------------------------------------------------------------------
+
+classes = (
+    WM_OT_OpenFilebrowser,
+    OBJECT_PT_urdf2blender_converter
+)
+
+
+def register():
+    for cls in classes:
+        try:
+            bpy.utils.register_class(cls)
+        except:
+            print("an exception when registering the class")
+
+def unregister():
+    for cls in reversed(classes):
+        try:
+            bpy.utils.unregister_class(cls)
+        except:
+            print("An exception was raised when unregistering the class")
+
+
+if __name__ == "__main__":
+    register()

--- a/script/urdfToBlender/urdfToBlender.py
+++ b/script/urdfToBlender/urdfToBlender.py
@@ -15,7 +15,11 @@ import xml.etree.ElementTree as ET
 
 from bpy.props import StringProperty, BoolProperty
 from bpy_extras.io_utils import ImportHelper
-from bpy.types import Operator
+from bpy.types import (Panel,
+                       Menu,
+                       Operator,
+                       PropertyGroup,
+                       )
 
 
 def createGeometricShape(iDynTree_solidshape):
@@ -327,9 +331,9 @@ def rigify(path):
     bpy.context.scene.transform_orientation_slots[0].type = 'LOCAL'
 
 
-class OT_TestOpenFilebrowser(Operator, ImportHelper):
+class WM_OT_OpenFilebrowser(Operator, ImportHelper):
 
-    bl_idname = "test.open_filebrowser"
+    bl_idname = "wm.open_filebrowser"
     bl_label = "Select the urdf"
 
     filter_glob: StringProperty(
@@ -349,21 +353,26 @@ class OT_TestOpenFilebrowser(Operator, ImportHelper):
 
         return {'FINISHED'}
 
+class OBJECT_PT_urdf2blender_converter(Panel):
+    bl_label = "URDF to Blender converter"
+    bl_idname = "OBJECT_PT_urdf2blender_converter"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "Tools"
+    bl_context = "objectmode"
+    row_convert = None
 
-def register():
-    bpy.utils.register_class(OT_TestOpenFilebrowser)
+    def draw(self, context):
+        layout = self.layout
+        scene = context.scene
+        row_configure = layout.row(align=True)
+        row_configure.operator("wm.open_filebrowser")
 
-def unregister():
-    bpy.utils.unregister_class(OT_TestOpenFilebrowser)
 
 # Main function
 def main(urdf_filename, blend_filename):
-    register()
-    if urdf_filename is None:
-        bpy.ops.test.open_filebrowser('INVOKE_DEFAULT')
-    else:
-        rigify(urdf_filename)
-        bpy.ops.wm.save_as_mainfile(filepath=blend_filename)
+    rigify(urdf_filename)
+    bpy.ops.wm.save_as_mainfile(filepath=blend_filename)
 
 
 


### PR DESCRIPTION
This PR made the converter a panel that can be installed as addon in blender as follow:


```console
$ cd ~/.config/blender/<blender_version>/scripts/addons/
$ ln -s /where/you/cloned/blender-robotics-utils/script/urdfToBlender  urdfToBlender
```
Going to Edit > Preferences > Add-ons > Testing:

![immagine](https://user-images.githubusercontent.com/19152494/154102247-16bfaf2e-1387-467f-a878-ed7cec306111.png)

If everything went fine you should have this panel on the right under the `Tools` section:

![immagine](https://user-images.githubusercontent.com/19152494/154102335-76c5312a-81ea-46b5-92cc-93d0668596e7.png)

After clicking "Select the urdf" it will be opened a file browse such as:

![immagine](https://user-images.githubusercontent.com/19152494/126337119-6b899183-1f2a-413c-8b88-4e5727818891.png)

After selecting the urdf, the script creates the rig of the robot in term of armature and meshes.