### PR TITLE
blenderRCBPanel: add list of controllable joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `blenderRCBPanel`
+
+- Added list of controllable joints for designing animations.
+
 ## [0.3.0] - 2022-02-28
 
 ### `addons_installer`

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ It should contain a list of pair where the first value will be the "YARP name" o
 Once configured, select the parts you want to control, press connect and then have fun!
 This has been tested with `iCub 2.5`.
 
-https://user-images.githubusercontent.com/60427731/145424773-e17e29b9-2229-4d3c-8f5e-fe40bd7725b6.mp4
+https://user-images.githubusercontent.com/19833605/159922346-0bc9cd53-1a5a-4ea1-a7f7-453bdbdc1547.mp4
+
 
 
 ### Known limitations

--- a/script/blenderRCBPanel/blenderRCBPanel.py
+++ b/script/blenderRCBPanel/blenderRCBPanel.py
@@ -123,14 +123,17 @@ class AllJoints:
 
     def __init__(self):
         self.annotations = {}
+        self.joint_names = []
         self.generate_joint_classes()
 
     def generate_joint_classes(self):
 
-        my_list = ["joint 1", "joint 2", "something elses"]
+        self.joint_names = bpy.data.objects[bpy.context.scene.my_tool.my_armature].pose.bones.keys()
 
-        #for joint in bpy.data.objects[bpy.context.scene.my_tool.my_armature].pose.bones.keys():
-        for joint in my_list:
+
+        # for joint_name, joint in bpy.data.objects[bpy.context.scene.my_tool.my_armature].pose.bones.items():
+
+        for joint in self.joint_names:
             self.annotations[joint] = FloatProperty(
                 name = joint,
                 description = joint,
@@ -197,8 +200,6 @@ class MyProperties(PropertyGroup):
         maxlen=1024,
         subtype='DIR_PATH'
         )
-
-    #__annotations__: AllJoints().generate_joint_classes()
 
 
 class ListItem(PropertyGroup):
@@ -345,8 +346,7 @@ class WM_OT_Configure(bpy.types.Operator):
                 {"__annotations__": robot.annotations},
         )
 
-        my_list = ["joint 1", "joint 2", "something elses"]
-        OBJECT_PT_robot_controller.set_joint_names(my_list)
+        # OBJECT_PT_robot_controller.set_joint_names(my_list)
         bpy.utils.register_class(JointProperties)
         bpy.types.Scene.my_joints = PointerProperty(type=JointProperties)
 
@@ -401,22 +401,13 @@ class OBJECT_PT_robot_controller(Panel):
         box_joints = layout.box()
         box_joints.label(text="joint angles")
 
-        #my_float: FloatProperty(
-        #    name = "Threshold(degrees)",
-        #    description = "Threshold for the safety checks",
-        #    default = 5.0,
-        #    min = 2.0,
-        #    max = 15.0)
         try:
             scene.my_joints
         except AttributeError:
             pass
         else:
-            my_list = ["joint 1", "joint 2", "something elses"]
-            #for joint in bpy.data.objects[mytool.my_armature].pose.bones.keys():
-            for joint in my_list:
+            for joint in bpy.data.objects[mytool.my_armature].pose.bones.keys():
                 box_joints.prop(scene.my_joints, joint)
-                
 
         if len(context.scene.my_list) == 0:
             box.enabled = False

--- a/script/blenderRCBPanel/blenderRCBPanel.py
+++ b/script/blenderRCBPanel/blenderRCBPanel.py
@@ -132,6 +132,8 @@ def float_callback(self, context):
             # It is a revolute joint
             else:
                 joint.rotation_euler[1] = joint_value * math.pi / 180.0
+                joint.keyframe_insert(data_path="rotation_euler")
+
     except AttributeError:
         pass
 


### PR DESCRIPTION
This PR adds the list of the controllable joints from the `blenderRCBPanel`.
When enter the values in the entries set the keyframes that form your animation.

This video displays the new behaviour of the panel

 https://user-images.githubusercontent.com/19833605/159922346-0bc9cd53-1a5a-4ea1-a7f7-453bdbdc1547.mp4