### PR TITLE
blenderRCBPanel: remove from the joint list the bones with drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `blenderRCBPanel`
+
+- Fixed when the urdf model is not saved inside the scene.
+- Removed from the list of joints the ones controlled via drivers.
+
 ## [0.4.0] - 2022-05-26
 
 ### `blenderRCBPanel`
@@ -32,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code refactored to be able to display the panel in the list of add-ons of blender
 
 ## [0.2.0] - 2021-11-29
+
 - Added action for automatically generate the rigs every time a commit
   is made in [`icub-models`](https://github.com/robotology/icub-models)
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # Blender Robotics Utils
+
 This repository contains utilities for exporting/controlling your robot in [Blender](https://www.blender.org/)
 
 ![ezgif com-gif-maker](https://user-images.githubusercontent.com/19152494/128324719-b9bda13d-92dd-49f5-b866-8dd04b3f9d76.gif)
 
 ## Maintainers
+
 This repository is maintained by:
 
 | | | |
 |:---:|:---:|:---:|
  [<img src="https://github.com/Nicogene.png" width="60">](https://github.com/niNicogenecogene) | [@Nicogene](https://github.com/Nicogene) | <img src="https://user-images.githubusercontent.com/4537987/134487985-e66b9dae-767d-4c3b-9ce1-9e6fb19cf07a.png" width="200"> |
 
-
 ## Addons installation
+
 ### Dependencies
+
 - Blender > 2.79
 - [iDynTree](https://github.com/robotology/idyntree) python bindings
 - `GAZEBO_MODEL_PATH` [properly set](https://github.com/robotology/icub-models#use-the-models-with-gazebo).
@@ -20,16 +23,19 @@ This repository is maintained by:
 An easy way to install the dependencies is to use the [conda](https://docs.conda.io/en/latest/) binaries packages.
 Just [install conda](https://github.com/robotology/robotology-superbuild/blob/master/doc/install-miniforge.md) and then:
 
-```
+```console
 conda create -n blenderenv
 conda activate blenderenv
 conda install -c conda-forge -c robotology python=<blender_py_ver> yarp idyntree
 conda env config vars set PYTHONPATH=/where/the/bindings/are/installed
 ```
+
 where `<blender_py_ver>` is the python version used inside Blender.
 
 ### Installation
+
 The addons can be installed by running the following command:
+
 ```console
 conda activate blenderenv
 cd blender-robotics-utils/script
@@ -37,20 +43,23 @@ blender -b --python-use-system-env -P ./addons_installer.py
 ```
 
 ## urdfToBlender
-Panel/Python script that given the urdf of a robot as input, define the complete rig, in terms of bones, meshes and joint limits.
 
+Panel/Python script that given the urdf of a robot as input, define the complete rig, in terms of bones, meshes and joint limits.
 
 ### Usage with GUI
 
 Once installed correctly the dependencies run:
 
 (Windows Powershell)
-```
+
+```console
  & "C:\Program Files\Blender Foundation\Blender <blender_version>\blender.exe" --python-use-system-env
 ```
+
 (Linux & macOs)
-```
-$ blender --python-use-system-env
+
+```console
+blender --python-use-system-env
 ```
 
 If the installation went fine you should have this panel on the right under the `Tools` section:
@@ -69,13 +78,15 @@ It is also possible to run this script from the command line interface, in this 
 to be converted and optionally the `blend_filename` to be saved(by default it saves `robot.blend` in the current directory).
 
 (Windows Powershell)
-```
- "C:\Program Files\Blender Foundation\Blender <blender_version>\blender.exe" --python-use-system-env -b -P "C:\where\you\have\blender-robotics-utils\script\urdfToBlender.py" -- --urdf_filename "C:\where\you\have\model.urdf" --blend_filename "C:\where\you\want\to\save\myrobot.blend"
 
+```console
+ "C:\Program Files\Blender Foundation\Blender <blender_version>\blender.exe" --python-use-system-env -b -P "C:\where\you\have\blender-robotics-utils\script\urdfToBlender.py" -- --urdf_filename "C:\where\you\have\model.urdf" --blend_filename "C:\where\you\want\to\save\myrobot.blend"
 ```
+
 (Linux & macOs)
-```
-$ blender --python-use-system-env -b -P "/where/you/have/blender-robotics-utils/script/urdfToBlender.py" -- --urdf_filename "/where/you/have/model.urdf" --blend_filename "/where/you/want/to/save/myrobot.blend"
+
+```console
+blender --python-use-system-env -b -P "/where/you/have/blender-robotics-utils/script/urdfToBlender.py" -- --urdf_filename "/where/you/have/model.urdf" --blend_filename "/where/you/want/to/save/myrobot.blend"
 ```
 
 ### Examples
@@ -84,17 +95,19 @@ $ blender --python-use-system-env -b -P "/where/you/have/blender-robotics-utils/
 |:---:|:---:|
 | ![immagine](https://user-images.githubusercontent.com/19152494/126991916-39b97bd1-da3b-4114-8597-9d835ad835a1.png) | ![immagine](https://user-images.githubusercontent.com/19152494/126991957-feb4eb6b-5ae0-4d3b-bfef-4ec05a5eaf10.png) |
 
-
 ### Known limitations
+
 - Only fixed or revolute joints are handled(see https://github.com/robotology/idyntree/issues/881, it requires iDynTree >= 3.3.0).
 - Only `.stl`, `.ply` and `.dae` format are supported for meshes.
 
 
 ## blenderRCBPanel 🚧
+
 Python addon that consists in a panel inside the pose mode for connecting parts of the rig to the parts of the real robot(or simulator).
 
 If the installation went fine you should have this panel on the right under the `Tools` section.
 First of all you have to configure it loading a `.json` file representing the structure of your robot like this one:
+
 ```json
 {
     "parts": [
@@ -106,8 +119,8 @@ First of all you have to configure it loading a `.json` file representing the st
         ["right_leg", "Right leg"]
     ]
 }
-
 ```
+
 It should contain a list of pair where the first value will be the "YARP name" of the part, and the second one will be the name displayed in the list.
 Once configured, select the parts you want to control, press connect and then have fun!
 This has been tested with `iCub 2.5`.
@@ -121,7 +134,9 @@ Video 🎥:
 https://user-images.githubusercontent.com/19833605/159922346-0bc9cd53-1a5a-4ea1-a7f7-453bdbdc1547.mp4
 
 ### Cartesian space
+
 #### Reach target
+
 1. The user selects the `Base Frame` and the `End Effector Frame` according to the joint he/she wants to move.
 2. Input the tranformation to be reached by `End Effector Frame` respect to `Base Frame`, in XYZ(meters) and RPY(degrees).
 3. Press `Reach target` button.
@@ -132,6 +147,7 @@ Video 🎥:
 https://user-images.githubusercontent.com/19152494/165498930-224c3871-620a-4c6c-9162-7e30c3578265.mp4
 
 #### Drag & Drop
+
 1. The user selects the `Base Frame` and the `End Effector Frame` according to the joint he/she wants to move.
 2. Press the button `Drag & Drop` to activate the feature. Once the button is pressed the user loses control of Blender.
 3. The user moves the mouse pointer in the 3D space of Blender and clicks the `right mouse button` to drop the position.
@@ -141,7 +157,6 @@ https://user-images.githubusercontent.com/19152494/165498930-224c3871-620a-4c6c-
 Video 🎥:
 
 https://user-images.githubusercontent.com/19833605/167880668-5176a0c1-3110-41dc-be9f-8e0565752430.mp4
-
 
 ### Known limitations
 

--- a/script/blenderRCBPanel/blenderRCBPanel.py
+++ b/script/blenderRCBPanel/blenderRCBPanel.py
@@ -690,7 +690,7 @@ class OT_OpenConfigurationFile(Operator, ImportHelper):
 
 
 def configure_ik():
-    if not hasattr(bpy.context.scene, 'model_urdf'):
+    if 'model_urdf' not in bpy.context.scene:
         ikv.configured = False
         return
     ikv.configured = True

--- a/script/blenderRCBPanel/blenderRCBPanel.py
+++ b/script/blenderRCBPanel/blenderRCBPanel.py
@@ -14,6 +14,8 @@ import idyntree.bindings as iDynTree
 import math
 import json
 from .common_functions import (printError,
+                               look_for_bones_with_drivers,
+                               bones_with_driver,
                                IkVariables as ikv,
                                InverseKinematics,
                                )
@@ -38,9 +40,6 @@ from bpy.types import (Panel,
                        )
 
 list_of_links = []
-
-# def printError(self, *args):
-#     self.report({"ERROR"}, " ".join(args))
 
 # ------------------------------------------------------------------------
 #    Structures
@@ -571,6 +570,9 @@ class OBJECT_PT_robot_controller(Panel):
 
     def draw(self, context):
 
+        if not bones_with_driver:
+            look_for_bones_with_drivers(context.scene.my_tool.my_armature)
+
         if ikv.iDynTreeModel is None:
             configure_ik()
 
@@ -626,6 +628,10 @@ class OBJECT_PT_robot_controller(Panel):
             pass
         else:
             for joint_name, joint in bpy.data.objects[mytool.my_armature].pose.bones.items():
+                # We do not have to add the entry in the list for the bones that have drivers
+                # since they have not to be controlled directly, but through the driver.s
+                if joint_name in bones_with_driver:
+                    continue
                 # Our bones rotate around y (revolute joint), translate along y (prismatic joint), if both are locked, it
                 # means it is a fixed joint.
                 if joint.lock_rotation[1] and joint.lock_location[1]:
@@ -647,7 +653,7 @@ class OBJECT_PT_robot_controller(Panel):
                 reach_box.enabled = False
             else:
                 box_joints.enabled = True
-                reach_box.enabled = True
+                reach_box.enabled = ikv.configured
                 if getattr(parts[scene.list_index], "value") in rcb_wrapper.keys():
                     row_disconnect.enabled = True
                     row_connect.enabled = False
@@ -684,7 +690,10 @@ class OT_OpenConfigurationFile(Operator, ImportHelper):
 
 
 def configure_ik():
-
+    if not hasattr(bpy.context.scene, 'model_urdf'):
+        ikv.configured = False
+        return
+    ikv.configured = True
     model_urdf = bpy.context.scene['model_urdf']
     mdlLoader = iDynTree.ModelLoader()
     mdlLoader.loadModelFromString(model_urdf)

--- a/script/blenderRCBPanel/common_functions.py
+++ b/script/blenderRCBPanel/common_functions.py
@@ -7,11 +7,19 @@ class IkVariables:
     inverseKinematics = iDynTree.InverseKinematics()
     dynComp = iDynTree.KinDynComputations()
     iDynTreeModel = None
+    configured = False
+
+bones_with_driver = []
 
 
 def printError(object, *args):
     object.report({"ERROR"}, " ".join(args))
 
+def look_for_bones_with_drivers(armature_name):
+    for joint_name in bpy.data.objects[armature_name].pose.bones.keys():
+        for d in bpy.context.object.animation_data.drivers:
+            if ('"%s"' % joint_name) in d.data_path:
+                bones_with_driver.append(joint_name)
 
 class InverseKinematics:
 

--- a/script/blenderRCBPanel/common_functions.py
+++ b/script/blenderRCBPanel/common_functions.py
@@ -17,6 +17,9 @@ def printError(object, *args):
 
 def look_for_bones_with_drivers(armature_name):
     for joint_name in bpy.data.objects[armature_name].pose.bones.keys():
+        # It means that there are no drivers
+        if bpy.context.object.animation_data is None:
+            return
         for d in bpy.context.object.animation_data.drivers:
             if ('"%s"' % joint_name) in d.data_path:
                 bones_with_driver.append(joint_name)


### PR DESCRIPTION
Moreover, we handled the case when the urdf is not saved in the scene. In this case the "cartesian" section is disabled.
Finally, we committed the `visuomanip` rig containing its urdf, in order to use the "reach target" panel.